### PR TITLE
Treat newlines as whitespace

### DIFF
--- a/EmojiTools/EmojiTools.swift
+++ b/EmojiTools/EmojiTools.swift
@@ -74,7 +74,7 @@ extension String {
     public static func containsEmojiOnly(string: String, allowWhitespace: Bool = true) -> Bool {
         var inputString = string
         if allowWhitespace {
-            inputString = string.stringByReplacingOccurrencesOfString(" ", withString: "")
+            inputString = string.componentsSeparatedByCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet()).joinWithSeparator("")
         }
         for scalar in inputString.unicodeScalars {
             if !scalar.isEmoji() {

--- a/EmojiToolsTests/EmojiToolsTests.swift
+++ b/EmojiToolsTests/EmojiToolsTests.swift
@@ -30,7 +30,7 @@ class EmojiToolsTests: XCTestCase {
 
     let nonEmojiString = "This string does not contain emoji."
     let emojiString = "This 😀😎👩‍👩‍👧‍👧 string 🌲🐯🌛 has 🍉☕️🍻 a 🎆🏀🎼 lot 🚌🗽✈️ of 📞🔦✉️ emoji. 8️⃣🔡🕒"
-    let emojiOnlyWhitespaceString = "😀😎👩‍👩‍👧‍👧 🌲🐯🌛 🍉☕️🍻 🎆🏀🎼   🚌🗽✈️     📞🔦✉️ 8️⃣🔡🕒"
+    let emojiOnlyWhitespaceString = "😀😎👩‍👩‍👧‍👧 🌲🐯🌛 🍉☕️🍻 🎆🏀🎼\n🚌🗽✈️      📞🔦✉️ 8️⃣🔡🕒"
     let emojiOnlyString = "😀😎👩‍👩‍👧‍👧🌲🐯🌛🍉☕️🍻🎆🏀🎼🚌🗽✈️📞🔦✉️8️⃣🔡🕒"
     let emojiCodeString = "The :monkey: is trying to buy a :banana: with some :moneybag: at the :convenience_store:."
 


### PR DESCRIPTION
When using the `public func containsEmojiOnly(allowWhitespace: Bool = true) -> Bool` function, I was surprised that only spaces were treated as whitespace. It seems like newlines should also count as whitespace—the only visible characters are emoji. This is how most emoji detection seems to work (Facebook Messenger, etc).
